### PR TITLE
changes Panning machine‘s block type

### DIFF
--- a/src/main/java/net/guizhanss/fastmachines/items/FastMachinesItems.java
+++ b/src/main/java/net/guizhanss/fastmachines/items/FastMachinesItems.java
@@ -84,7 +84,7 @@ public final class FastMachinesItems {
     );
     public static final SlimefunItemStack FAST_PANNING_MACHINE = FastMachines.getLocalization().getItem(
         "FAST_PANNING_MACHINE",
-        Material.HOPPER
+        Material.LOOM
     );
     public static final SlimefunItemStack FAST_JUICER = FastMachines.getLocalization().getItem(
         "FAST_JUICER",


### PR DESCRIPTION
使用时发现漏斗仍会正常吸入物品，且挖掉机器时不会掉落吸入的物品，属于意料以外的情况。
将快捷淘金机的方块改为织布机，应该可以避免该情况。
